### PR TITLE
fixes default commit build date bug

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -57,12 +58,16 @@ type App struct {
 	Writer io.Writer
 }
 
-// Tries to find out when this binary was compiled.
-// Returns the current time if it fails to find it.
-func compileTime() time.Time {
-	info, err := os.Stat(os.Args[0])
+// mustCompileTime - determines the modification time of the current binary
+func mustCompileTime() time.Time {
+	path, err := exec.LookPath(os.Args[0])
 	if err != nil {
-		return time.Now()
+		return time.Time{}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}
 	}
 	return info.ModTime()
 }
@@ -75,7 +80,7 @@ func NewApp() *App {
 		Version:      "0.0.0",
 		BashComplete: DefaultAppComplete,
 		Action:       helpCommand.Action,
-		Compiled:     compileTime(),
+		Compiled:     mustCompileTime(),
 		Writer:       os.Stdout,
 	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/codegangsta/cli"
+	"github.com/minio-io/cli"
 )
 
 func ExampleApp() {

--- a/cli_test.go
+++ b/cli_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"os"
 
-	"github.com/codegangsta/cli"
+	"github.com/minio-io/cli"
 )
 
 func Example() {

--- a/command_test.go
+++ b/command_test.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/codegangsta/cli"
+	"github.com/minio-io/cli"
 )
 
 func TestCommandDoNotIgnoreFlags(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codegangsta/cli"
+	"github.com/minio-io/cli"
 )
 
 func TestNewContext(t *testing.T) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/codegangsta/cli"
+	"github.com/minio-io/cli"
 )
 
 var boolFlagTests = []struct {


### PR DESCRIPTION
If a copy of binary is not in the current working dir, it returns current time instead of mod time. This patch fixes this bug.
