### PR TITLE
Adds constants to customize mc help content

### DIFF
--- a/command.go
+++ b/command.go
@@ -68,6 +68,10 @@ type Command struct {
 	EnvVarSetCommand string
 	// Assignment operator to set the environment variable, specific to OS
 	AssignmentOperator string
+	// Disable history for security reasons
+	DisableHistory string
+	// Enable history
+	EnableHistory string
 
 	// CustomHelpTemplate the text template for the command help topic.
 	// cli.go uses text/template to render templates. You can

--- a/constants_unix.go
+++ b/constants_unix.go
@@ -7,6 +7,6 @@ const (
 	defaultPrompt             = "$"
 	defaultEnvSetCmd          = "export"
 	defaultAssignmentOperator = "="
-	defaultDisableHistory     = "set +o history"
-	defaultEnableHistory      = "set -o history"
+	defaultDisableHistory     = "$ set +o history"
+	defaultEnableHistory      = "$ set -o history"
 )

--- a/constants_unix.go
+++ b/constants_unix.go
@@ -7,4 +7,6 @@ const (
 	defaultPrompt             = "$"
 	defaultEnvSetCmd          = "export"
 	defaultAssignmentOperator = "="
+	defaultDisableHistory     = "set +o history"
+	defaultEnableHistory      = "set -o history"
 )

--- a/constants_windows.go
+++ b/constants_windows.go
@@ -5,4 +5,9 @@ const (
 	defaultPrompt             = "C:\\>"
 	defaultEnvSetCmd          = "set"
 	defaultAssignmentOperator = "="
+	defaultDisableHistory     = "For security reasons, disable Windows history activity momentarily.\n" +
+		"     Go to \"Settings/Privacy/Activity history\" and click on check boxes,\n" +
+		"     \"Store my activity on this device\" and \"Send my activity history to\n" +
+		"     Microsoft\" to deselect and disable the history activity."
+	defaultEnableHistory = "Click and select \"Store my activity on this device\" check box to enable history activity."
 )

--- a/help.go
+++ b/help.go
@@ -190,6 +190,14 @@ func ShowCommandHelp(ctx *Context, command string) error {
 			c.AssignmentOperator = defaultAssignmentOperator
 		}
 
+		if c.DisableHistory == "" {
+			c.DisableHistory = defaultDisableHistory
+		}
+
+		if c.EnableHistory == "" {
+			c.EnableHistory = defaultEnableHistory
+		}
+
 		if c.HasName(command) {
 			if c.CustomHelpTemplate != "" {
 				HelpPrinterCustom(ctx.App.Writer, c.CustomHelpTemplate, c, nil)


### PR DESCRIPTION
2 more constants to disable/enable history for mc commands that exposes secret-key or password. We have examples like below. 
```
  1. Add MinIO service under "myminio" alias. For security reasons turn off bash history momentarily.
      $ set +o history
      $ {{.HelpName}} myminio http://localhost:9000 minio minio123
      $ set -o history
```

These will be replaced with:
```
  1. Add MinIO service under "myminio" alias. For security reasons turn off bash history momentarily.
      {{.DisableHistory}}
      {{.Prompt}} {{.HelpName}} myminio http://localhost:9000 minio minio123
      {{.EnableHistory}}
```