### PR TITLE
Show custom help for App level as well

### DIFF
--- a/app.go
+++ b/app.go
@@ -94,6 +94,17 @@ type App struct {
 	// render custom help text by setting this variable.
 	CustomAppHelpTemplate string
 
+	// Default prompt, specific to OS
+	Prompt string
+	// Command to set the environment variable, specific to OS
+	EnvVarSetCommand string
+	// Assignment operator to set the environment variable, specific to OS
+	AssignmentOperator string
+	// Disable history for security reasons
+	DisableHistory string
+	// Enable history
+	EnableHistory string
+
 	didSetup bool
 }
 

--- a/help.go
+++ b/help.go
@@ -172,7 +172,33 @@ func ShowCommandHelpAndExit(c *Context, command string, code int) {
 func ShowCommandHelp(ctx *Context, command string) error {
 	// show the subcommand help for a command with subcommands
 	if command == "" {
-		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		template := SubcommandHelpTemplate
+		if ctx.App.CustomAppHelpTemplate != "" {
+			template = ctx.App.CustomAppHelpTemplate
+		}
+
+		// If not set, set these values before printing help.
+		if ctx.App.Prompt == "" {
+			ctx.App.Prompt = defaultPrompt
+		}
+
+		if ctx.App.EnvVarSetCommand == "" {
+			ctx.App.EnvVarSetCommand = defaultEnvSetCmd
+		}
+
+		if ctx.App.AssignmentOperator == "" {
+			ctx.App.AssignmentOperator = defaultAssignmentOperator
+		}
+
+		if ctx.App.DisableHistory == "" {
+			ctx.App.DisableHistory = defaultDisableHistory
+		}
+
+		if ctx.App.EnableHistory == "" {
+			ctx.App.EnableHistory = defaultEnableHistory
+		}
+
+		HelpPrinter(ctx.App.Writer, template, ctx.App)
 		return nil
 	}
 


### PR DESCRIPTION
When a command is a parent for other sub-commands and has a custom help
text defined, use that instead of the default help template