### PR TITLE
Add HelpWriter field to customize help output

### DIFF
--- a/app.go
+++ b/app.go
@@ -81,9 +81,11 @@ type App struct {
 	Author string
 	// Email of Author (Note: Use App.Authors, this is deprecated)
 	Email string
-	// Writer writer to write output to
+	// Writer for standard output
 	Writer io.Writer
-	// ErrWriter writes error output
+	// HelpWriter for help output
+	HelpWriter io.Writer
+	// ErrWriter for error outptu
 	ErrWriter io.Writer
 	// Other custom info
 	Metadata map[string]interface{}
@@ -120,6 +122,7 @@ func NewApp() *App {
 		Action:       helpCommand.Action,
 		Compiled:     compileTime(),
 		Writer:       os.Stdout,
+		HelpWriter:   os.Stdout,
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -184,6 +184,7 @@ func ExampleApp_Run_commandHelp() {
 func ExampleApp_Run_noAction() {
 	app := App{}
 	app.Name = "greet"
+	app.HelpWriter = os.Stdout
 	app.Run([]string{"greet"})
 	// Output:
 	// NAME:
@@ -203,6 +204,7 @@ func ExampleApp_Run_noAction() {
 func ExampleApp_Run_subcommandNoAction() {
 	app := App{}
 	app.Name = "greet"
+	app.HelpWriter = os.Stdout
 	app.Commands = []Command{
 		{
 			Name:        "describeit",
@@ -621,7 +623,7 @@ func TestApp_SetStdout(t *testing.T) {
 
 	app := NewApp()
 	app.Name = "test"
-	app.Writer = w
+	app.HelpWriter = w
 
 	err := app.Run([]string{"help"})
 	if err != nil {
@@ -1030,6 +1032,7 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 		app := NewApp()
 		buf := new(bytes.Buffer)
 		app.Writer = buf
+		app.HelpWriter = buf
 
 		subCmdBar := Command{
 			Name:  "bar",
@@ -1074,7 +1077,7 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 func TestApp_Run_SubcommandFullPath(t *testing.T) {
 	app := NewApp()
 	buf := new(bytes.Buffer)
-	app.Writer = buf
+	app.HelpWriter = buf
 	app.Name = "command"
 	subCmd := Command{
 		Name:  "bar",
@@ -1104,7 +1107,7 @@ func TestApp_Run_SubcommandFullPath(t *testing.T) {
 func TestApp_Run_SubcommandHelpName(t *testing.T) {
 	app := NewApp()
 	buf := new(bytes.Buffer)
-	app.Writer = buf
+	app.HelpWriter = buf
 	app.Name = "command"
 	subCmd := Command{
 		Name:     "bar",
@@ -1135,7 +1138,7 @@ func TestApp_Run_SubcommandHelpName(t *testing.T) {
 func TestApp_Run_CommandHelpName(t *testing.T) {
 	app := NewApp()
 	buf := new(bytes.Buffer)
-	app.Writer = buf
+	app.HelpWriter = buf
 	app.Name = "command"
 	subCmd := Command{
 		Name:  "bar",
@@ -1162,11 +1165,10 @@ func TestApp_Run_CommandHelpName(t *testing.T) {
 		t.Errorf("expected full path to subcommand: %s", output)
 	}
 }
-
 func TestApp_Run_CommandSubcommandHelpName(t *testing.T) {
 	app := NewApp()
 	buf := new(bytes.Buffer)
-	app.Writer = buf
+	app.HelpWriter = buf
 	app.Name = "base"
 	subCmd := Command{
 		Name:     "bar",
@@ -1205,7 +1207,7 @@ func TestApp_Run_Help(t *testing.T) {
 		app := NewApp()
 		app.Name = "boom"
 		app.Usage = "make an explosive entrance"
-		app.Writer = buf
+		app.HelpWriter = buf
 		app.Action = func(c *Context) error {
 			buf.WriteString("boom I say!")
 			return nil
@@ -1276,7 +1278,7 @@ func TestApp_Run_Categories(t *testing.T) {
 		},
 	}
 	buf := new(bytes.Buffer)
-	app.Writer = buf
+	app.HelpWriter = buf
 
 	app.Run([]string{"categories"})
 

--- a/command.go
+++ b/command.go
@@ -297,6 +297,7 @@ func (c Command) startApp(ctx *Context) error {
 	app.Author = ctx.App.Author
 	app.Email = ctx.App.Email
 	app.Writer = ctx.App.Writer
+	app.HelpWriter = ctx.App.HelpWriter
 	app.ErrWriter = ctx.App.ErrWriter
 
 	app.categories = CommandCategories{}

--- a/help.go
+++ b/help.go
@@ -135,7 +135,7 @@ func ShowAppHelpAndExit(c *Context, exitCode int) {
 // ShowAppHelp is an action that displays the help.
 func ShowAppHelp(c *Context) (err error) {
 	if c.App.CustomAppHelpTemplate == "" {
-		HelpPrinter(c.App.Writer, AppHelpTemplate, c.App)
+		HelpPrinter(c.App.HelpWriter, AppHelpTemplate, c.App)
 		return
 	}
 	customAppData := func() map[string]interface{} {
@@ -146,7 +146,7 @@ func ShowAppHelp(c *Context) (err error) {
 			"ExtraInfo": c.App.ExtraInfo,
 		}
 	}
-	HelpPrinterCustom(c.App.Writer, c.App.CustomAppHelpTemplate, c.App, customAppData())
+	HelpPrinterCustom(c.App.HelpWriter, c.App.CustomAppHelpTemplate, c.App, customAppData())
 	return nil
 }
 
@@ -172,7 +172,7 @@ func ShowCommandHelpAndExit(c *Context, command string, code int) {
 func ShowCommandHelp(ctx *Context, command string) error {
 	// show the subcommand help for a command with subcommands
 	if command == "" {
-		HelpPrinter(ctx.App.Writer, SubcommandHelpTemplate, ctx.App)
+		HelpPrinter(ctx.App.HelpWriter, SubcommandHelpTemplate, ctx.App)
 		return nil
 	}
 
@@ -200,9 +200,9 @@ func ShowCommandHelp(ctx *Context, command string) error {
 
 		if c.HasName(command) {
 			if c.CustomHelpTemplate != "" {
-				HelpPrinterCustom(ctx.App.Writer, c.CustomHelpTemplate, c, nil)
+				HelpPrinterCustom(ctx.App.HelpWriter, c.CustomHelpTemplate, c, nil)
 			} else {
-				HelpPrinter(ctx.App.Writer, CommandHelpTemplate, c)
+				HelpPrinter(ctx.App.HelpWriter, CommandHelpTemplate, c)
 			}
 			return nil
 		}

--- a/help_test.go
+++ b/help_test.go
@@ -146,7 +146,7 @@ func Test_helpCommand_Action_ErrorIfNoTopic(t *testing.T) {
 func Test_helpCommand_InHelpOutput(t *testing.T) {
 	app := NewApp()
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"test", "--help"})
 
 	s := output.String()
@@ -202,7 +202,7 @@ func TestShowAppHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"foo", "--help"})
 
 	if !strings.Contains(output.String(), "frobbly, fr, frob") {
@@ -224,7 +224,7 @@ func TestShowCommandHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"foo", "help", "fr"})
 
 	if !strings.Contains(output.String(), "frobbly") {
@@ -250,7 +250,7 @@ func TestShowSubcommandHelp_CommandAliases(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"foo", "help"})
 
 	if !strings.Contains(output.String(), "frobbly, fr, frob, bork") {
@@ -285,7 +285,7 @@ EXAMPLES:
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"foo", "help", "frobbly"})
 
 	if strings.Contains(output.String(), "2. Frobbly runs without this param locally.") {
@@ -321,7 +321,7 @@ func TestShowAppHelp_HiddenCommand(t *testing.T) {
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"app", "--help"})
 
 	if strings.Contains(output.String(), "secretfrob") {
@@ -379,7 +379,7 @@ VERSION:
 	}
 
 	output := &bytes.Buffer{}
-	app.Writer = output
+	app.HelpWriter = output
 	app.Run([]string{"app", "--help"})
 
 	if strings.Contains(output.String(), "secretfrob") {


### PR DESCRIPTION
Set to os.Stdout by default, HelpWriter can be set to another writer, such as a pipe to a terminal pager