### PR TITLE
Do not print help after errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -199,7 +199,6 @@ func (a *App) Run(arguments []string) (err error) {
 	context := NewContext(a, set, nil)
 	if nerr != nil {
 		fmt.Fprintln(a.Writer, nerr)
-		ShowAppHelp(context)
 		return nerr
 	}
 	context.shellComplete = shellComplete
@@ -215,7 +214,6 @@ func (a *App) Run(arguments []string) (err error) {
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
-		ShowAppHelp(context)
 		return err
 	}
 
@@ -245,7 +243,6 @@ func (a *App) Run(arguments []string) (err error) {
 		beforeErr := a.Before(context)
 		if beforeErr != nil {
 			fmt.Fprintf(a.Writer, "%v\n\n", beforeErr)
-			ShowAppHelp(context)
 			HandleExitCoder(beforeErr)
 			err = beforeErr
 			return err
@@ -322,11 +319,6 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 	if nerr != nil {
 		fmt.Fprintln(a.Writer, nerr)
 		fmt.Fprintln(a.Writer)
-		if len(a.Commands) > 0 {
-			ShowSubcommandHelp(context)
-		} else {
-			ShowCommandHelp(ctx, context.Args().First())
-		}
 		return nerr
 	}
 
@@ -341,7 +333,6 @@ func (a *App) RunAsSubcommand(ctx *Context) (err error) {
 			return err
 		}
 		fmt.Fprintf(a.Writer, "%s %s\n\n", "Incorrect Usage.", err.Error())
-		ShowSubcommandHelp(context)
 		return err
 	}
 

--- a/command.go
+++ b/command.go
@@ -185,7 +185,6 @@ func (c Command) Run(ctx *Context) (err error) {
 	if nerr != nil {
 		fmt.Fprintln(ctx.App.Writer, nerr)
 		fmt.Fprintln(ctx.App.Writer)
-		ShowCommandHelp(ctx, c.Name)
 		return nerr
 	}
 
@@ -203,7 +202,6 @@ func (c Command) Run(ctx *Context) (err error) {
 		}
 		fmt.Fprintln(context.App.Writer, "Incorrect Usage:", err.Error())
 		fmt.Fprintln(context.App.Writer)
-		ShowCommandHelp(context, c.Name)
 		return err
 	}
 
@@ -230,7 +228,6 @@ func (c Command) Run(ctx *Context) (err error) {
 		if err != nil {
 			fmt.Fprintln(context.App.Writer, err)
 			fmt.Fprintln(context.App.Writer)
-			ShowCommandHelp(context, c.Name)
 			HandleExitCoder(err)
 			return err
 		}


### PR DESCRIPTION
It is not really useful to print a help page after printing an error, 
most users will not notice the first line which is the error description.

`./mc admin --unexpected-flag`